### PR TITLE
Feat/application

### DIFF
--- a/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
@@ -1,0 +1,34 @@
+package goormthon_group4.backend.domain.application.controller;
+
+import goormthon_group4.backend.domain.application.dto.request.ApplicationRequestDto;
+import goormthon_group4.backend.domain.application.dto.response.ApplicationResponseDto;
+import goormthon_group4.backend.domain.application.service.ApplicationService;
+import goormthon_group4.backend.global.auth.CustomUserDetails;
+import goormthon_group4.backend.global.common.exception.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "팀 지원 API", description = "팀에 대한 지원서 제출하는 기능")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/applications")
+public class ApplicationController {
+    private final ApplicationService applicationService;
+
+    @PostMapping(consumes = "multipart/form-data")
+    @Operation(summary = "팀 과제 지원서 제출", description = "지정된 팀에 지원서를 제출")
+    public ApiResponse<ApplicationResponseDto> submitApplication(
+            @RequestPart("application") ApplicationRequestDto applicationRequestDto,
+            @RequestPart(value = "file", required = false) MultipartFile multipartFile,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        ApplicationResponseDto responseDto = applicationService.submitApplication(applicationRequestDto, customUserDetails, multipartFile);
+        return ApiResponse.success(responseDto);
+    }}

--- a/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
@@ -1,6 +1,7 @@
 package goormthon_group4.backend.domain.application.controller;
 
 import goormthon_group4.backend.domain.application.dto.request.ApplicationRequestDto;
+import goormthon_group4.backend.domain.application.dto.request.ApplicationStatusUpdateRequest;
 import goormthon_group4.backend.domain.application.dto.response.ApplicationResponseDto;
 import goormthon_group4.backend.domain.application.service.ApplicationService;
 import goormthon_group4.backend.global.auth.CustomUserDetails;
@@ -13,30 +14,53 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Tag(name = "팀 지원 API", description = "지원서 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/applications")
+@RequestMapping("api/v1/teams")
 public class ApplicationController {
     private final ApplicationService applicationService;
 
-    @PostMapping(consumes = "multipart/form-data")
-    @Operation(summary = "팀 과제 지원서 제출", description = "지정된 팀에 지원서를 제출")
+    @PostMapping(value = "/{teamId}/applications", consumes = "multipart/form-data")
+    @Operation(summary = "팀에 지원서 제출", description = "지정된 팀에 지원서를 제출")
     public ApiResponse<ApplicationResponseDto> submitApplication(
+            @PathVariable Long teamId,
             @RequestPart("application") ApplicationRequestDto applicationRequestDto,
             @RequestPart(value = "file", required = false) MultipartFile multipartFile,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        ApplicationResponseDto responseDto = applicationService.submitApplication(applicationRequestDto, customUserDetails, multipartFile);
+        ApplicationResponseDto responseDto = applicationService.submitApplication(teamId, applicationRequestDto, customUserDetails, multipartFile);
         return ApiResponse.success(responseDto);
     }
 
+    @GetMapping("/{teamId}/applications/{userId}")
     @Operation(summary = "팀장의 특정 지원서 조회", description = "팀장만 접근 가능")
-    @GetMapping("/{teamId}/{userId}")
     public ApiResponse<ApplicationResponseDto> getApplication(
             @PathVariable Long teamId,
             @PathVariable Long userId,
-            @AuthenticationPrincipal CustomUserDetails cutomUserDetails) {
-        return ApiResponse.success(applicationService.getApplication(teamId, userId, cutomUserDetails));
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ApiResponse.success(applicationService.getApplication(teamId, userId, customUserDetails));
+    }
+
+    @GetMapping("/{teamId}/applications")
+    @Operation(summary = "지원서 전체 조회", description = "팀장이 해당 팀에 제출된 모든 지원서를 조회")
+    public ApiResponse<List<ApplicationResponseDto>> getApplications(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        List<ApplicationResponseDto> responses = applicationService.getApplicationsByTeamId(teamId, customUserDetails);
+        return ApiResponse.success(responses);
+    }
+
+    @PatchMapping("/{teamId}/applications/{userId}/status")
+    @Operation(summary = "지원서 상태 변경", description = "팀장이 지원자의 지원 상태 변경")
+    public ApiResponse<ApplicationStatusUpdateRequest> updateApplicationStatus(
+            @PathVariable Long teamId,
+            @PathVariable Long userId,
+            @RequestBody ApplicationStatusUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        ApplicationStatusUpdateRequest updated = applicationService.updateApplication(teamId, userId, request, customUserDetails);
+        return ApiResponse.success(updated);
     }
 }

--- a/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
@@ -8,14 +8,12 @@ import goormthon_group4.backend.global.common.exception.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "팀 지원 API", description = "팀에 대한 지원서 제출하는 기능")
+@Tag(name = "팀 지원 API", description = "지원서 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/applications")
@@ -31,4 +29,14 @@ public class ApplicationController {
     ) {
         ApplicationResponseDto responseDto = applicationService.submitApplication(applicationRequestDto, customUserDetails, multipartFile);
         return ApiResponse.success(responseDto);
-    }}
+    }
+
+    @Operation(summary = "팀장의 특정 지원서 조회", description = "팀장만 접근 가능")
+    @GetMapping("/{teamId}/{userId}")
+    public ApiResponse<ApplicationResponseDto> getApplication(
+            @PathVariable Long teamId,
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails cutomUserDetails) {
+        return ApiResponse.success(applicationService.getApplication(teamId, userId, cutomUserDetails));
+    }
+}

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/request/ApplicationRequestDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/request/ApplicationRequestDto.java
@@ -1,0 +1,27 @@
+package goormthon_group4.backend.domain.application.dto.request;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ApplicationRequestDto {
+    private Long teamId;
+
+    private String name;
+    private String email;
+    private String phoneNumber;
+
+    private String introduce;
+    private String purpose;
+    private String skillExperience;
+    private String strengthsExperience;
+    private String additionalInfo;
+
+    private MultipartFile file; // 첨부파일
+
+}

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/request/ApplicationStatusUpdateRequest.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/request/ApplicationStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package goormthon_group4.backend.domain.application.dto.request;
+
+import goormthon_group4.backend.domain.application.entity.ApplicationStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApplicationStatusUpdateRequest {
+    private ApplicationStatus status;
+}

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
@@ -1,0 +1,38 @@
+package goormthon_group4.backend.domain.application.dto.response;
+
+import goormthon_group4.backend.domain.application.entity.Application;
+import goormthon_group4.backend.domain.application.entity.ApplicationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ApplicationResponseDto {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String phoneNumber;
+
+    private String introduce;
+    private String purpose;
+    private String skillExperience;
+    private String strengthsExperience;
+
+    private String fileUrl;
+    private ApplicationStatus status;
+
+    @Builder
+    public ApplicationResponseDto(Application application) {
+        this.id = application.getId();
+        this.name = application.getName();
+        this.email = application.getEmail();
+        this.phoneNumber = application.getPhoneNumber();
+        this.introduce = application.getIntroduce();
+        this.purpose = application.getPurpose();
+        this.skillExperience = application.getSkillExperience();
+        this.strengthsExperience = application.getStrengthsExperience();
+    }
+}

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
@@ -24,15 +24,22 @@ public class ApplicationResponseDto {
     private String fileUrl;
     private ApplicationStatus status;
 
-    @Builder
-    public ApplicationResponseDto(Application application) {
-        this.id = application.getId();
-        this.name = application.getName();
-        this.email = application.getEmail();
-        this.phoneNumber = application.getPhoneNumber();
-        this.introduce = application.getIntroduce();
-        this.purpose = application.getPurpose();
-        this.skillExperience = application.getSkillExperience();
-        this.strengthsExperience = application.getStrengthsExperience();
+    private Long userId;
+    private Long teamId;
+
+    public static ApplicationResponseDto from(Application application) {
+        return ApplicationResponseDto.builder()
+                .id(application.getId())
+                .name(application.getName())
+                .email(application.getEmail())
+                .phoneNumber(application.getPhoneNumber())
+                .introduce(application.getIntroduce())
+                .purpose(application.getPurpose())
+                .skillExperience(application.getSkillExperience())
+                .strengthsExperience(application.getStrengthsExperience())
+                .fileUrl(application.getFileUrl())
+                .userId(application.getUser().getId())
+                .teamId(application.getTeam().getId())
+                .build();
     }
 }

--- a/src/main/java/goormthon_group4/backend/domain/application/entity/Application.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/entity/Application.java
@@ -67,4 +67,8 @@ public class Application extends BaseEntity {
   @Column(nullable = true)
   private String additionalInfo; // nullable
 
+  // 지원서 상태 변경
+  public void changeStatus(ApplicationStatus status) {
+    this.status = status;
+  }
 }

--- a/src/main/java/goormthon_group4/backend/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/repository/ApplicationRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
     // 특정 유저가 특정 팀에 이미 지원했는지 확인
-    boolean existsByUserId(User user, Team team);
+    boolean existsByUserAndTeam(User user, Team team);
 
     // 특정 팀에 속한 지원서 모두 조회
     List<Application> findAllByTeam(Team team);
@@ -19,5 +19,5 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     List<Application> findAllByUser(User user);
 
     // 유저와 팀 기준으로 지원서 단건 조회
-    Optional<Application> findByUserAndTeam(Team team, User user);
+    Optional<Application> findByUserAndTeam(User user, Team team);
 }

--- a/src/main/java/goormthon_group4/backend/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/repository/ApplicationRepository.java
@@ -1,0 +1,23 @@
+package goormthon_group4.backend.domain.application.repository;
+
+import goormthon_group4.backend.domain.application.entity.Application;
+import goormthon_group4.backend.domain.team.entity.Team;
+import goormthon_group4.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+    // 특정 유저가 특정 팀에 이미 지원했는지 확인
+    boolean existsByUserId(User user, Team team);
+
+    // 특정 팀에 속한 지원서 모두 조회
+    List<Application> findAllByTeam(Team team);
+
+    // 특정 유저가 작성한 모든 지원서 조회
+    List<Application> findAllByUser(User user);
+
+    // 유저와 팀 기준으로 지원서 단건 조회
+    Optional<Application> findByUserAndTeam(Team team, User user);
+}

--- a/src/main/java/goormthon_group4/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/service/ApplicationService.java
@@ -1,0 +1,65 @@
+package goormthon_group4.backend.domain.application.service;
+
+import goormthon_group4.backend.domain.application.dto.request.ApplicationRequestDto;
+import goormthon_group4.backend.domain.application.dto.response.ApplicationResponseDto;
+import goormthon_group4.backend.domain.application.entity.Application;
+import goormthon_group4.backend.domain.application.entity.ApplicationStatus;
+import goormthon_group4.backend.domain.application.repository.ApplicationRepository;
+import goormthon_group4.backend.domain.s3.service.S3Service;
+import goormthon_group4.backend.domain.team.entity.Team;
+import goormthon_group4.backend.domain.team.repository.TeamRepository;
+import goormthon_group4.backend.domain.user.entity.User;
+import goormthon_group4.backend.domain.user.repository.UserRepository;
+import goormthon_group4.backend.global.auth.CustomUserDetails;
+import goormthon_group4.backend.global.common.exception.CustomException;
+import goormthon_group4.backend.global.common.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public ApplicationResponseDto submitApplication(ApplicationRequestDto applicationRequestDto,
+                                                    CustomUserDetails customUserDetails,
+                                                    MultipartFile multipartFile) {
+        User user = customUserDetails.getUser();
+
+        // 팀 ID를 기반으로 팀 조회
+        Team team = teamRepository.findById(applicationRequestDto.getTeamId())
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        // 포트폴리오 파일 업로드 (nullable)
+        String fileurl = null;
+        if(multipartFile != null && !multipartFile.isEmpty()) {
+            fileurl = s3Service.uploadFile(multipartFile);
+        }
+
+        // Application Entity 생성 및 저장
+        Application application = Application.builder()
+                .status(ApplicationStatus.PENDING)
+                .team(team)
+                .user(user)
+                .name(applicationRequestDto.getName())
+                .email(applicationRequestDto.getEmail())
+                .phoneNumber(applicationRequestDto.getPhoneNumber())
+                .introduce(applicationRequestDto.getIntroduce())
+                .purpose(applicationRequestDto.getPurpose())
+                .skillExperience(applicationRequestDto.getSkillExperience())
+                .strengthsExperience(applicationRequestDto.getStrengthsExperience())
+                .additionalInfo(applicationRequestDto.getAdditionalInfo())
+                .fileUrl(fileurl)
+                .build();
+
+        applicationRepository.save(application);
+        return new ApplicationResponseDto(application);
+    }
+}

--- a/src/main/java/goormthon_group4/backend/global/common/exception/CustomException.java
+++ b/src/main/java/goormthon_group4/backend/global/common/exception/CustomException.java
@@ -11,4 +11,9 @@ public class CustomException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + message);
+        this.errorCode = errorCode;
+    }
 }


### PR DESCRIPTION
## 👀 이슈
resolve #19 

## 📌 개요
- Application(지원서) 관련 API 구현
- 특정 팀에 지원서 제출, 팀장은 조회, 상태 변경 가능
## 👩‍💻 작업 사항
	•지원서 제출 API (POST /applications/{teamId})
	•지원서 단건 조회 API (GET /applications/{teamId}/{userId}) - 팀장 전용
	•지원서 전체 조회 API (GET /applications/{teamId}/applications) - 팀장 전용
	•지원서 상태 변경 API (PATCH /applications/{teamId}/applications/{userId}/status) - 팀장 전용
	•ApplicationRequestDto, ApplicationResponseDto, ApplicationStatusUpdateRequest DTO 구현

## ✅ 참고 사항
	•지원서 상태 변경 시 PATCH 메서드를 사용하여 상태만 업데이트
	•프론트에서 팀 ID를 path variable로 넘겨야 함 (/applications/{teamId})
