### PR TITLE
Feat/finaloutput

### DIFF
--- a/src/main/java/goormthon_group4/backend/domain/s3/service/S3Service.java
+++ b/src/main/java/goormthon_group4/backend/domain/s3/service/S3Service.java
@@ -15,7 +15,6 @@ import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -61,5 +60,20 @@ public class S3Service {
       throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
     }
 
+  }
+
+  public void deleteFile(String fileUrl) {
+    try {
+      // s3 버킷에서 key 추출
+      String key = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+
+      // s3에서 삭제
+      s3Client.deleteObject(b -> b
+              .bucket(bucket)
+              .key(key)
+      );
+    } catch (Exception e) {
+      throw new CustomException(ErrorCode.FILE_DELETE_FAILED);
+    }
   }
 }

--- a/src/main/java/goormthon_group4/backend/domain/s3/service/S3Service.java
+++ b/src/main/java/goormthon_group4/backend/domain/s3/service/S3Service.java
@@ -57,6 +57,7 @@ public class S3Service {
 
       return fileUrl;
     } catch (Exception e) {
+      e.printStackTrace();
       throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
     }
 

--- a/src/main/java/goormthon_group4/backend/domain/team/controller/TeamController.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/controller/TeamController.java
@@ -1,5 +1,6 @@
 package goormthon_group4.backend.domain.team.controller;
 
+import goormthon_group4.backend.domain.team.dto.request.OutputUploadDto;
 import goormthon_group4.backend.domain.team.dto.request.TeamCreateRequest;
 import goormthon_group4.backend.domain.team.dto.request.TeamUpdateRequest;
 import goormthon_group4.backend.domain.team.dto.response.MyTeamResponse;
@@ -15,8 +16,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "팀 API")
 @RestController
@@ -81,9 +84,17 @@ public class TeamController {
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
     return ApiResponse.success(teamService.getTeamsByUserId(userDetails.getUser().getId()));
-
-
   }
+
+  @Operation(summary = "최종 산출물 제출", description = "팀에서 최종 산출물을 업로드합니다.")
+  @PostMapping(value = "{id}/output", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ApiResponse<String> uploadFinalOutput(@PathVariable Long id,
+                                               @RequestPart("file") MultipartFile file,
+                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+    String fileUrl = teamService.uploadFinalOutput(id, file, userDetails.getUser());
+    return ApiResponse.success(fileUrl);
+  }
+
 
 
 

--- a/src/main/java/goormthon_group4/backend/domain/team/controller/TeamController.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/controller/TeamController.java
@@ -95,6 +95,22 @@ public class TeamController {
     return ApiResponse.success(fileUrl);
   }
 
+  @Operation(summary = "!최종 산출물 제출 하나씩!", description = "팀에서 최종 산출물 하나를 삭제합니다.")
+  @DeleteMapping("/output/{outputId}")
+  public ApiResponse<String> deleteFinalOutput(@PathVariable Long outputId,
+                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+    teamService.deleteOutput(outputId, userDetails.getUser());
+    return ApiResponse.success("산출물이 성공적으로 삭제되었습니다.");
+  }
+
+  @Operation(summary = "팀 산출물 전체 삭제", description = "특정 팀의 모든 산출물을 삭제합니다.")
+  @DeleteMapping("/team/{teamId}/outputs")
+  public ApiResponse<String> deleteAllOutputsByTeam(@PathVariable Long teamId,
+                                                    @AuthenticationPrincipal CustomUserDetails userDetails) {
+    teamService.deleteAllOutputsByTeam(teamId, userDetails.getUser());
+    return ApiResponse.success("해당 팀의 모든 산출물이 삭제되었습니다.");
+  }
+
 
 
 

--- a/src/main/java/goormthon_group4/backend/domain/team/dto/request/OutputUploadDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/dto/request/OutputUploadDto.java
@@ -1,0 +1,11 @@
+package goormthon_group4.backend.domain.team.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class OutputUploadDto {
+    private MultipartFile file;
+}

--- a/src/main/java/goormthon_group4/backend/domain/team/entity/Output.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/entity/Output.java
@@ -29,7 +29,7 @@ public class Output extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 2048)
   private String fileUrl;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/goormthon_group4/backend/domain/team/exception/TeamErrorCode.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/exception/TeamErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum TeamErrorCode implements BaseErrorCode {
   TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "팀을 찾을 수 없습니다."),
-  PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "프로젝트를 찾을 수 없습니다.");
+  PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "프로젝트를 찾을 수 없습니다."),
+  OUTPUT_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "산출물을 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/goormthon_group4/backend/domain/team/repository/OutputRepository.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/repository/OutputRepository.java
@@ -1,10 +1,12 @@
 package goormthon_group4.backend.domain.team.repository;
 
 import goormthon_group4.backend.domain.team.entity.Output;
+import goormthon_group4.backend.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface OutputRepository extends JpaRepository<Output, Long> {
     List<Output> findAllByTeamId(Long teamId);
+    List<Output> findAllByTeam(Team team);
 }

--- a/src/main/java/goormthon_group4/backend/domain/team/repository/OutputRepository.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/repository/OutputRepository.java
@@ -1,0 +1,10 @@
+package goormthon_group4.backend.domain.team.repository;
+
+import goormthon_group4.backend.domain.team.entity.Output;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OutputRepository extends JpaRepository<Output, Long> {
+    List<Output> findAllByTeamId(Long teamId);
+}

--- a/src/main/java/goormthon_group4/backend/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/goormthon_group4/backend/global/common/exception/code/ErrorCode.java
@@ -38,8 +38,8 @@ public enum ErrorCode implements BaseErrorCode {
   // 500 INTERNAL SERVER ERROR
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500_001", "서버 내부 오류가 발생했습니다."),
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500_002", "알 수 없는 오류가 발생했습니다."),
-  FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500_003", "파일 업로드에 실패했습니다.");
-
+  FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500_003", "파일 업로드에 실패했습니다."),
+  FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500_004", "파일 삭제에 실패했습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;


### PR DESCRIPTION
## 👀 이슈
resolve #27 

## 📌 개요
- 최종산출물 삭제, 업로드

## 👩‍💻 작업 사항
•	Output 엔티티 및 OutputRepository 생성
•	S3 파일 삭제 기능 구현
•	파일 URL 길이 초과 이슈 해결 (fileUrl 컬럼 길이 2048로 확장)
•	예외 처리 (OUTPUT_NOT_FOUND, FILE_UPLOAD_FAILED 등) 추가

## ✅ 참고 사항
•	파일 업로드는 multipart/form-data 형식으로 요청해야 합니다
•	id 재정렬은 안됨
