### PR TITLE
Fix/application

### DIFF
--- a/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
@@ -52,7 +52,7 @@ public class ApplicationController {
     public ApiResponse<List<ApplicationResponseDto>> getApplications(
             @PathVariable Long teamId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        List<ApplicationResponseDto> responses = applicationService.getApplicationsByTeamId(teamId, customUserDetails);
+        List<ApplicationResponseDto> responses = applicationService.getNonAcceptedApplicaationsByTeamId(teamId, customUserDetails);
         return ApiResponse.success(responses);
     }
 

--- a/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/controller/ApplicationController.java
@@ -31,8 +31,8 @@ public class ApplicationController {
             @ModelAttribute ApplicationRequestDto applicationRequestDto,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        MultipartFile file = applicationRequestDto.getFile(); // null일 수 있음
-        ApplicationResponseDto applicationResponseDto = applicationService.submitApplication(teamId, applicationRequestDto, customUserDetails, file);
+        List<MultipartFile> files = applicationRequestDto.getFileUrls(); // null일 수 있음
+        ApplicationResponseDto applicationResponseDto = applicationService.submitApplication(teamId, applicationRequestDto, customUserDetails, files);
         return ApiResponse.success(applicationResponseDto);
     }
 

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/request/ApplicationRequestDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/request/ApplicationRequestDto.java
@@ -1,6 +1,10 @@
 package goormthon_group4.backend.domain.application.dto.request;
 
 
+import goormthon_group4.backend.domain.application.dto.response.ApplicationResponseDto;
+import goormthon_group4.backend.domain.application.entity.Application;
+import goormthon_group4.backend.domain.user.entity.User;
+import goormthon_group4.backend.domain.user.entity.UserInfo;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,4 +27,5 @@ public class ApplicationRequestDto {
     private String additionalInfo;
 
     private MultipartFile file; // 첨부파일
+
 }

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/request/ApplicationRequestDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/request/ApplicationRequestDto.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -26,6 +28,5 @@ public class ApplicationRequestDto {
     private String strengthsExperience;
     private String additionalInfo;
 
-    private MultipartFile file; // 첨부파일
-
+    private List<MultipartFile> fileUrls;
 }

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
@@ -57,4 +57,5 @@ public class ApplicationResponseDto {
                 .teamId(application.getTeam().getId())
                 .submittedAt(application.getCreatedAt())  // createdAt도 매핑해주면 좋음
                 .build();
-    }}
+    }
+}

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
@@ -2,9 +2,13 @@ package goormthon_group4.backend.domain.application.dto.response;
 
 import goormthon_group4.backend.domain.application.entity.Application;
 import goormthon_group4.backend.domain.application.entity.ApplicationStatus;
+import goormthon_group4.backend.domain.user.entity.User;
+import goormthon_group4.backend.domain.user.entity.UserInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -16,6 +20,7 @@ public class ApplicationResponseDto {
     private String email;
     private String phoneNumber;
 
+    private String imgUrl;
     private String introduce;
     private String purpose;
     private String skillExperience;
@@ -27,19 +32,27 @@ public class ApplicationResponseDto {
     private Long userId;
     private Long teamId;
 
+    private LocalDateTime submittedAt;
+
+
     public static ApplicationResponseDto from(Application application) {
+        User user = application.getUser();
+        UserInfo userInfo = user.getUserInfo();
+
         return ApplicationResponseDto.builder()
                 .id(application.getId())
                 .name(application.getName())
                 .email(application.getEmail())
                 .phoneNumber(application.getPhoneNumber())
+                .imgUrl(userInfo != null ? userInfo.getImgUrl() : null)
                 .introduce(application.getIntroduce())
                 .purpose(application.getPurpose())
                 .skillExperience(application.getSkillExperience())
                 .strengthsExperience(application.getStrengthsExperience())
                 .fileUrl(application.getFileUrl())
-                .userId(application.getUser().getId())
+                .status(application.getStatus())
+                .userId(user.getId())
                 .teamId(application.getTeam().getId())
+                .submittedAt(application.getCreatedAt())  // createdAt도 매핑해주면 좋음
                 .build();
-    }
-}
+    }}

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
@@ -25,6 +25,7 @@ public class ApplicationResponseDto {
     private String purpose;
     private String skillExperience;
     private String strengthsExperience;
+    private String additionalInfo;
 
     private String fileUrl;
     private ApplicationStatus status;
@@ -49,6 +50,7 @@ public class ApplicationResponseDto {
                 .purpose(application.getPurpose())
                 .skillExperience(application.getSkillExperience())
                 .strengthsExperience(application.getStrengthsExperience())
+                .additionalInfo(application.getAdditionalInfo())
                 .fileUrl(application.getFileUrl())
                 .status(application.getStatus())
                 .userId(user.getId())

--- a/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/dto/response/ApplicationResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -27,7 +28,7 @@ public class ApplicationResponseDto {
     private String strengthsExperience;
     private String additionalInfo;
 
-    private String fileUrl;
+    private List<String> fileUrls;
     private ApplicationStatus status;
 
     private Long userId;
@@ -51,7 +52,7 @@ public class ApplicationResponseDto {
                 .skillExperience(application.getSkillExperience())
                 .strengthsExperience(application.getStrengthsExperience())
                 .additionalInfo(application.getAdditionalInfo())
-                .fileUrl(application.getFileUrl())
+                .fileUrls(application.getFileUrls())
                 .status(application.getStatus())
                 .userId(user.getId())
                 .teamId(application.getTeam().getId())

--- a/src/main/java/goormthon_group4/backend/domain/application/entity/Application.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/entity/Application.java
@@ -3,21 +3,15 @@ package goormthon_group4.backend.domain.application.entity;
 import goormthon_group4.backend.domain.team.entity.Team;
 import goormthon_group4.backend.domain.user.entity.User;
 import goormthon_group4.backend.global.common.base.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -61,8 +55,13 @@ public class Application extends BaseEntity {
   @Column(nullable = false)
   private String strengthsExperience;
 
-  @Column(length = 1000, nullable = true)
-  private String fileUrl; // nullable
+//  @Column(length = 2048, nullable = true)
+//  private String fileUrl; // nullable
+
+  @ElementCollection
+  @CollectionTable(name = "application_file_urls", joinColumns = @JoinColumn(name = "application_id"))
+  @Column(name = "file_url", length = 2048) // ✅ 길이 늘리기
+  private List<String> fileUrls = new ArrayList<>();
 
   @Column(nullable = true)
   private String additionalInfo; // nullable

--- a/src/main/java/goormthon_group4/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/goormthon_group4/backend/domain/application/service/ApplicationService.java
@@ -140,6 +140,17 @@ public class ApplicationService {
         return request;
     }
 
+    @Transactional(readOnly = true)
+    public List<ApplicationResponseDto> getNonAcceptedApplicaationsByTeamId(Long teamId, CustomUserDetails userDetails) {
+        Team team = getTeamOrThrow(teamId);
+        checkTeamLeader(team, userDetails.getUser());
+
+        return applicationRepository.findAllByTeam(team).stream()
+                .filter(app -> app.getStatus() != ApplicationStatus.ACCEPT)
+                .map(ApplicationResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
     // =========================== ⬇️ 헬퍼 메서드 정리 ⬇️ ===========================
 
     private Team getTeamOrThrow(Long teamId) {


### PR DESCRIPTION
## 👀 이슈
resolve #46 

## 📌 개요
1.지원서 전체 조회 시 유저의 프로필 이미지와 신청일자 반환하게해야 합니다.
5.최종산출물 업로드 API 필요
7.지원서 조회 시 status가 null로 나옴. 수락한 지원서가 조회 시 그대로 남아있음
11.특정 지원서 조회시 반환객체에 "기타사항" 입력한 내용을 안 주고 있습니다.
12.지원서 첨부파일을 여러개 첨부할 수 있는데(디자인, 프론트 상에서) 지원서 조회 시 파일 하나만 나옵니다. 배열형태로 파일 저장하는게 좋아보임

## 👩‍💻 작업 사항

작업한 내용을 작성해 주세요

## ✅ 참고 사항

공유할 내용 및 관련 스크린샷 등을 넣어 주세요
