### PR TITLE
feat : 최종 산출물 다중 파일 업로드, 응답 DTO 추가

### DIFF
--- a/src/main/java/goormthon_group4/backend/domain/team/controller/TeamController.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/controller/TeamController.java
@@ -5,11 +5,7 @@ import goormthon_group4.backend.domain.team.dto.request.OutputUploadDto;
 import goormthon_group4.backend.domain.team.dto.request.TeamCreateRequest;
 import goormthon_group4.backend.domain.team.dto.request.TeamUpdateOnlyStatusRequest;
 import goormthon_group4.backend.domain.team.dto.request.TeamUpdateRequest;
-import goormthon_group4.backend.domain.team.dto.response.MyTeamResponse;
-import goormthon_group4.backend.domain.team.dto.response.TeamCreateResponse;
-import goormthon_group4.backend.domain.team.dto.response.TeamDetailResponse;
-import goormthon_group4.backend.domain.team.dto.response.TeamResponse;
-import goormthon_group4.backend.domain.team.dto.response.TeamUpdateResponse;
+import goormthon_group4.backend.domain.team.dto.response.*;
 import goormthon_group4.backend.domain.team.service.TeamService;
 import goormthon_group4.backend.global.auth.CustomUserDetails;
 import goormthon_group4.backend.global.common.exception.response.ApiResponse;
@@ -104,11 +100,11 @@ public class TeamController {
 
   @Operation(summary = "최종 산출물 제출", description = "팀에서 최종 산출물을 업로드합니다.")
   @PostMapping(value = "{teamId}/output", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ApiResponse<String> uploadFinalOutput(@PathVariable Long teamId,
-                                               @RequestPart("file") MultipartFile file,
-                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
-    String fileUrl = teamService.uploadFinalOutput(teamId, file, userDetails.getUser());
-    return ApiResponse.success(fileUrl);
+  public ApiResponse<List<OutputUploadResponseDto>> uploadFinalOutput(@PathVariable Long teamId,
+                                                                      @RequestPart("files") List<MultipartFile> files,
+                                                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    List<OutputUploadResponseDto> fileUrls = teamService.uploadFinalOutputs(teamId, files, userDetails.getUser());
+    return ApiResponse.success(fileUrls);
   }
 
   @Operation(summary = "!최종 산출물 제출 하나씩!", description = "팀에서 최종 산출물 하나를 삭제합니다.")

--- a/src/main/java/goormthon_group4/backend/domain/team/dto/request/OutputUploadDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/dto/request/OutputUploadDto.java
@@ -4,8 +4,10 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class OutputUploadDto {
-    private MultipartFile file;
+    private List<MultipartFile> file;
 }

--- a/src/main/java/goormthon_group4/backend/domain/team/dto/response/OutputUploadResponseDto.java
+++ b/src/main/java/goormthon_group4/backend/domain/team/dto/response/OutputUploadResponseDto.java
@@ -1,0 +1,21 @@
+package goormthon_group4.backend.domain.team.dto.response;
+
+import goormthon_group4.backend.domain.team.entity.Output;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OutputUploadResponseDto {
+    private Long id;
+    private String fileUrl;
+
+    public static OutputUploadResponseDto from(Output output) {
+        return OutputUploadResponseDto.builder()
+                .id(output.getId())
+                .fileUrl(output.getFileUrl())
+                .build();
+    }
+}


### PR DESCRIPTION
## 👀 이슈
resolve #이슈번호

## 📌 개요
최종 산출물을 다중 파일로 업로드할 수 있도록 기능을 확장하고, 각 파일에 대한 정보를 응답받을 수 있도록 수정했습니다.

## 👩‍💻 작업 사항
•	POST /{teamId}/output 엔드포인트에서 다중 파일(MultipartFile[]) 업로드 처리
•	Output 엔티티 저장 로직 수정 (파일마다 한 개씩 저장)
•	응답을 위한 OutputUploadResponseDto 생성 및 리스트 반환
•	기존 단일 파일 업로드에서 다중 파일 업로드 방식으로 전환

## ✅ 참고 사항
•	프론트에서는 multipart/form-data로 files 필드에 여러 파일을 담아 요청해야 합니다.
